### PR TITLE
feat: 사용자 인증 미들웨어 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 .DS_Store
 .env
+service-account.json

--- a/routes/controllers/friends.Controller.js
+++ b/routes/controllers/friends.Controller.js
@@ -20,7 +20,7 @@ exports.getFriendList = async (req, res, next) => {
 };
 
 exports.addFriend = async (req, res, next) => {
-  const myUid = req.userData
+  const myUid = req.userData.uid;
   const friendUid = req.body.uid;
 
   try {
@@ -33,7 +33,10 @@ exports.addFriend = async (req, res, next) => {
     }
 
     friendList.push(friend.uid);
-    await User.findOneAndUpdate({ uid: myUid }, { $set: { friends: friendList } });
+    await User.findOneAndUpdate(
+      { uid: myUid },
+      { $set: { friends: friendList } }
+    );
 
     res.status(201).json({ message: "Add complete" });
   } catch (error) {

--- a/routes/controllers/signup.Controller.js
+++ b/routes/controllers/signup.Controller.js
@@ -16,7 +16,7 @@ exports.createUser = async (req, res, next) => {
       res.json({ message: "success" });
     }
   } catch (error) {
-    res.status(500).send({ message: "server error" });
+    res.status(500).json({ message: "server error" });
     next(error);
   }
 };

--- a/routes/controllers/signup.Controller.js
+++ b/routes/controllers/signup.Controller.js
@@ -16,7 +16,7 @@ exports.createUser = async (req, res, next) => {
       res.json({ message: "success" });
     }
   } catch (error) {
-    res.send({ message: "server error" });
+    res.status(500).send({ message: "server error" });
     next(error);
   }
 };

--- a/routes/friends.js
+++ b/routes/friends.js
@@ -1,7 +1,8 @@
 const express = require("express");
 const router = express.Router();
+const auth = require("./middlewares/auth");
 const friendsController = require("./controllers/friends.Controller");
 
-router.get("/", friendsController.getFriendList);
+router.get("/", auth, friendsController.getFriendList);
 
 module.exports = router;

--- a/routes/middlewares/auth.js
+++ b/routes/middlewares/auth.js
@@ -1,22 +1,21 @@
-// const admin = require('firebase-admin');
+const admin = require("firebase-admin");
 
-// const serviceAccount = require('need SDK.json file');
+const serviceAccount = require("../../service-account.json");
 
-// admin.initializeApp({
-//   credential: admin.credential.cert(serviceAccount)
-// });
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+});
 
-// const verifyToken = async (req, res, next) => {
-//   try {
-//     const token = req.headers.authorization.split('Bearer ')[1];
-//     const uid = await admin.auth().verifyIdToken(token);
+const verifyToken = async (req, res, next) => {
+  try {
+    const token = req.headers.authorization.split("Bearer ")[1];
+    const userData = await admin.auth().verifyIdToken(token);
+    req.userData = userData;
+    next();
+  } catch (error) {
+    res.status(401);
+    return res.send({ message: "유저확인 불가" });
+  }
+};
 
-//     req.userData = uid;
-//     next();
-//   } catch (error) {
-//     res.status(401);
-//     return res.send({ message: '유저확인 불가' });
-//   }
-// };
-
-// module.exports = verifyToken;
+module.exports = verifyToken;

--- a/routes/middlewares/auth.js
+++ b/routes/middlewares/auth.js
@@ -10,6 +10,7 @@ const verifyToken = async (req, res, next) => {
   try {
     const token = req.headers.authorization.split("Bearer ")[1];
     const userData = await admin.auth().verifyIdToken(token);
+
     req.userData = userData;
     next();
   } catch (error) {

--- a/routes/middlewares/auth.js
+++ b/routes/middlewares/auth.js
@@ -15,7 +15,7 @@ const verifyToken = async (req, res, next) => {
     next();
   } catch (error) {
     res.status(401);
-    return res.send({ message: "유저확인 불가" });
+    return res.json({ message: "유저확인 불가" });
   }
 };
 

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -1,7 +1,8 @@
 const express = require("express");
 const router = express.Router();
+const auth = require("./middlewares/auth");
 const signupController = require("./controllers/signup.controller");
 
-router.post("/", signupController.createUser);
+router.post("/", auth, signupController.createUser);
 
 module.exports = router;


### PR DESCRIPTION
- axios 요청 시 정상적으로 토큰이 넘어오는 것을 확인하고 auth 미들웨어 구현완료하였습니다.
- 기존에 완성한 /signup PUT, /friends GET에 인증 적용하였습니다.
- auth 미들웨어 자체에서 토큰을 디코딩하고 그 결과값인 유저정보를 다음 미들웨어 혹은 컨트롤러(엔드포인트)로 넘겨줍니다.
- auth 미들웨어를 거쳐도 axios요청의 data(req.body)를 다음 미들웨어로 넘겨줍니다(예를 들어 axios의 data에서 실어서 보낸 uid는 다음 미들웨어로 넘겨줍니다 )
- 에러처리에 대한 의견 부탁드립니다! 현재 인증에 오류가 발생하면 res.send로 응답하고 있는데 res.json과 어떤 방식이 좋을까요?