### PR TITLE
feat/1003: 채팅창 구현

### DIFF
--- a/config/socket.js
+++ b/config/socket.js
@@ -24,8 +24,16 @@ exports.loader = (server) => {
       socket.join(roomId);
     });
 
-    socket.on("message", (message) => {
-      socket.to(message.roomName).emit("message", message);
+    socket.on("message", async (content) => {
+      const user = content.user;
+      const friend = content.roomName.replace(user, "");
+
+      socket.to(content.roomName).emit("message", content);
+      await chatRooms.updateChatRoom({ user, friend, message: content });
+    });
+
+    socket.on("save messages", async ({ contents }) => {
+      await chatRooms.saveChatRoom(contents);
     });
 
     socket.on("disconnect", () => {

--- a/models/Chat.js
+++ b/models/Chat.js
@@ -6,7 +6,11 @@ const MessageSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
-    content: String,
+    message: String,
+    timestamps: {
+      type: Number,
+      required: true,
+    },
   },
   { timestamps: true }
 );

--- a/queries/chatRoom.js
+++ b/queries/chatRoom.js
@@ -1,15 +1,27 @@
 const ChatRooms = require("../models/Chat");
 
 exports.findOrCreateChatRoom = async ({ user, friend }) => {
-  const chatRooms = await ChatRooms.find({});
-  let myChatRoom = chatRooms.find((chatRoom) => {
-    if (chatRoom.users.includes(user) && chatRoom.users.includes(friend))
-      return chatRoom;
-  });
+  const chatRoom = await ChatRooms.findOne({ users: { $all: [user, friend] } });
 
-  if (!myChatRoom) {
-    myChatRoom = await ChatRooms.create({ users: [user, friend] });
-  }
+  if (chatRoom) return chatRoom;
 
-  return myChatRoom;
+  return ChatRooms.create({ users: [user, friend] });
+};
+
+exports.updateChatRoom = async ({ user, friend, message }) => {
+  const chatRoom = await ChatRooms.findOneAndUpdate(
+    { users: { $all: [user, friend] } },
+    { $push: { contents: message } }
+  );
+
+  return chatRoom;
+};
+
+exports.saveChatRoom = async ({ user, friend, messages }) => {
+  const chatRoom = await ChatRooms.findOneAndUpdate(
+    { users: { $all: [user, friend] } },
+    { $set: { contents: messages } }
+  );
+
+  return chatRoom;
 };

--- a/routes/controllers/friends.Controller.js
+++ b/routes/controllers/friends.Controller.js
@@ -22,6 +22,10 @@ exports.addFriend = async (req, res, next) => {
   try {
     const friend = await User.findOne({ name: req.body.friendName });
     const user = await User.findOne({ uid: myUid });
+
+    if (user.name === friend.name)
+      return res.status(400).json({ message: "자신을 추가할 수 없습니다!" });
+
     const friendList = user.friends;
 
     if (friendList.includes(friend.uid)) {


### PR DESCRIPTION
## 개요

- [칸반링크](https://www.notion.so/vanillacoding/b89c35d6298d468295daa3119c92c920)
- mongoDB의 query의 기존에 있던 코드에서 더 효율적으로 사용할 수 있는 $all operator를 알게 돼서 사용했습니다.
- 이전의 schema를 최대한 변경하지 않는 로직으로 고민하는게 어려웠습니다.

## 작업사항

- chatRoom query에서 socket에서 받은 메세지를 저장하는 로직

## 변경로직

- 채팅방에서 message 저장하거나 업데이트 하는 로직
- timestamps를 직접 model에 넣었습니다. 
- 기존 mongoose에서 주는 timestamps를 이용할 수 있는 로직으로 구현했던 게 아니라서, 당장 급하게 생각나는 방식으로 추가했습니다.

## 리뷰시 체크리스트

- chatRoom.js와 socket.js에서 save message받는 부분을 보시면 됩니다.

## 기타
